### PR TITLE
Fixes copy path from A to B when path is unspecified

### DIFF
--- a/index.py
+++ b/index.py
@@ -205,7 +205,7 @@ def sync_servers(instanceA_contents, instanceB_language_id, instanceB_contentIds
     for content in instanceA_contents:
         if content[content_id_key] not in instanceB_contentIds:
             title = content.get('title') or content.get('artistName')
-            instance_path = instanceB_path or basename(content.get('path'))
+            instance_path = instanceB_path or content.get('path')
 
             # if given this, we want to filter from instance by profile id
             if instanceA_profile_filter_id:

--- a/index.py
+++ b/index.py
@@ -8,7 +8,7 @@ import configparser
 import sys
 import time
 import re
-from os.path import basename
+from os.path import dirname
 
 from config import (
     instanceA_url, instanceA_key,  instanceA_path, instanceA_profile,
@@ -205,7 +205,7 @@ def sync_servers(instanceA_contents, instanceB_language_id, instanceB_contentIds
     for content in instanceA_contents:
         if content[content_id_key] not in instanceB_contentIds:
             title = content.get('title') or content.get('artistName')
-            instance_path = instanceB_path or content.get('path')
+            instance_path = instanceB_path or dirname(content.get('path'))
 
             # if given this, we want to filter from instance by profile id
             if instanceA_profile_filter_id:


### PR DESCRIPTION
Hello,

Documentation states for path that:

`path = /data/Movies # if not given will use RadarrA path for each movie - may not be what you want!`

This is not the case with {{basename()}} as it only takes the name of the folder, causing an error (tested with Sonarr).  
This patch fixes it using {{dirname()}} instead, which provides only the parent call to the API call of B.

For instance, if source is stored in "/data/movies/My Movie (2020)", then API call will have root folder set to "/data/movies", which is the expected value.