### PR TITLE
Trust environment variables for Python requests

### DIFF
--- a/index.py
+++ b/index.py
@@ -344,9 +344,7 @@ def sync_content():
 
     # get sessions
     instanceA_session = requests.Session()
-    instanceA_session.trust_env = False
     instanceB_session = requests.Session()
-    instanceB_session.trust_env = False
 
     # check if we tested if we are using v2 or v3
     if not tested_api_version:


### PR DESCRIPTION
There's no point in setting trust_env to False. Keeping it default (True) would allow users to add a custom certificate through environment variables (by setting REQUESTS_CA_BUNDLE, for instance, to an internal CA).