### PR TITLE
send data with json content type

### DIFF
--- a/index.py
+++ b/index.py
@@ -266,7 +266,7 @@ def sync_servers(instanceA_contents, instanceB_language_id, instanceB_contentIds
             elif content_not_synced:
                 # sync content if not synced
                 logging.info(f'syncing content title "{title}"')
-                sync_response = instanceB_session.post(instanceB_content_url, data=json.dumps(formatted_content))
+                sync_response = instanceB_session.post(instanceB_content_url, json=formatted_content)
                 # check response and save content id for searching later on if success
                 if sync_response.status_code != 201 and sync_response.status_code != 200:
                     logger.error(f'server sync error for {title} - response: {sync_response.text}')
@@ -288,7 +288,7 @@ def sync_servers(instanceA_contents, instanceB_language_id, instanceB_contentIds
                     if matching_content_instanceB['monitored'] != content['monitored']:
                         matching_content_instanceB['monitored'] = content['monitored']
                         instanceB_content_url = get_content_put_path(instanceB_url, instanceB_key, matching_content_instanceB.get('id'))
-                        sync_response = instanceB_session.put(instanceB_content_url, data=json.dumps(matching_content_instanceB))
+                        sync_response = instanceB_session.put(instanceB_content_url, json=matching_content_instanceB)
                         # check response and save content id for searching later on if success
                         if sync_response.status_code != 202:
                             logger.error(f'server monitoring sync error for {title} - response: {sync_response.text}')


### PR DESCRIPTION
Fix for issue https://github.com/syncarr/syncarr/issues/83

The latest version of Radarr returns "415 Unsupported Media Type" error when json text is posted.  This fix sends the requests with the content-type "application/json".

It has been tested and is working on both latest (4.0.0.5473) and older (3.2.2.5080) versions of Radarr.