### PR TITLE
Fix README rendering for code blocks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.11.0b5
 
 ENV IS_IN_DOCKER 1
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Syncs two Radarr/Sonarr/Lidarr servers through the web API. Useful for syncing a
  1. Edit the config.conf file and enter your servers URLs and API keys for each server.  
  2. Add the profile name (case insensitive) and movie path for the Radarr instance the movies will be synced to:
 
-   ```ini
+    ```ini
     [radarrA]
     url = https://4k.example.com:443
     key = XXXXX
@@ -43,6 +43,7 @@ Syncs two Radarr/Sonarr/Lidarr servers through the web API. Useful for syncing a
     key = XXXXX
     profile = 1080p
     path = /data/Shows
+    ```
 
  4. Or if you want to sync two Lidarr instances:
  5. 


### PR DESCRIPTION
Hello, 
The README file wasn't rendered properly because of missing backticks.