### PR TITLE
Fix code block formatting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Syncs two Radarr/Sonarr/Lidarr servers through the web API. Useful for syncing a
  1. Edit the config.conf file and enter your servers URLs and API keys for each server.  
  2. Add the profile name (case insensitive) and movie path for the Radarr instance the movies will be synced to:
 
-   ```ini
+     ```ini
     [radarrA]
     url = https://4k.example.com:443
     key = XXXXX
@@ -43,9 +43,10 @@ Syncs two Radarr/Sonarr/Lidarr servers through the web API. Useful for syncing a
     key = XXXXX
     profile = 1080p
     path = /data/Shows
+    ```
 
  4. Or if you want to sync two Lidarr instances:
- 5. 
+
     ```ini
     [lidarrA]
     url = https://lossless.example.com:443


### PR DESCRIPTION
Was doing some setup and noticed that the README had some odd formatting around the codeblocks in the list. 