### PR TITLE
Fixes for JSON data and markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Syncs two Radarr/Sonarr/Lidarr servers through the web API. Useful for syncing a
 * Supports Docker for multiple instances
 * Can set interval for syncing
 * Support two way sync (one way by default)
-* Skip content with missing files
+* Skip content with missing files (Radarr only)
 * Set language profiles (Sonarr v3 only)
 * Filter syncing by content file quality (Radarr only)
 * Filter syncing by tags (Sonarr/Radarr v3 only)
@@ -77,7 +77,7 @@ Syncs two Radarr/Sonarr/Lidarr servers through the web API. Useful for syncing a
     [general]
     sync_bidirectionally = 1 # sync from instance A to B **AND** instance B to A
     auto_search = 0 # search is automatically started on new content - disable by setting to 0 (default 1)
-    skip_missing = 1 # content with missing files are skipped on sync - disable by setting to 0 (default 1)
+    skip_missing = 1 # content with missing files are skipped on sync - disable by setting to 0 (default 1) (Radarr only)
     monitor_new_content = 0 # set to 0 to never monitor new content synced or to 1 to always monitor new content synced (default 1)
     test_run = 1 # enable test mode - will run through sync program but will not actually sync content
     ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Syncs two Radarr/Sonarr/Lidarr servers through the web API. Useful for syncing a
 * Supports Docker for multiple instances
 * Can set interval for syncing
 * Support two way sync (one way by default)
+* Skip content with missing files
 * Set language profiles (Sonarr v3 only)
 * Filter syncing by content file quality (Radarr only)
 * Filter syncing by tags (Sonarr/Radarr v3 only)
@@ -76,6 +77,7 @@ Syncs two Radarr/Sonarr/Lidarr servers through the web API. Useful for syncing a
     [general]
     sync_bidirectionally = 1 # sync from instance A to B **AND** instance B to A
     auto_search = 0 # search is automatically started on new content - disable by setting to 0 (default 1)
+    skip_missing = 1 # content with missing files are skipped on sync - disable by setting to 0 (default 1)
     monitor_new_content = 0 # set to 0 to never monitor new content synced or to 1 to always monitor new content synced (default 1)
     test_run = 1 # enable test mode - will run through sync program but will not actually sync content
     ```

--- a/config.py
+++ b/config.py
@@ -170,6 +170,16 @@ if auto_search is not None:
 else:
     auto_search = 1
 
+# set to skip missing if config not set
+skip_missing = get_config_value('SYNCARR_SKIP_MISSING', 'skip_missing', 'general')
+if skip_missing is not None:
+    try:
+        skip_missing = int(skip_missing)
+    except ValueError:
+        skip_missing = 0
+else:
+    skip_missing = 1
+
 # set to monitor if config not set
 monitor_new_content = get_config_value('SYNCARR_MONITOR_NEW_CONTENT', 'monitor_new_content', 'general')
 if monitor_new_content is not None:
@@ -497,6 +507,7 @@ logger.debug({
     'monitor_new_content': monitor_new_content,
     'sync_bidirectionally': sync_bidirectionally,
     'auto_search': auto_search,
+    'skip_missing': skip_missing,
     'api_version': api_version,
 })
 

--- a/config.py
+++ b/config.py
@@ -79,6 +79,8 @@ radarrA_profile = get_config_value('RADARR_A_PROFILE', 'profile', 'radarrA')
 radarrA_profile_id = get_config_value('RADARR_A_PROFILE_ID', 'profile_id', 'radarrA')
 radarrA_profile_filter = get_config_value('RADARR_A_PROFILE_FILTER', 'profile_filter', 'radarrA')
 radarrA_profile_filter_id = get_config_value('RADARR_A_PROFILE_FILTER_ID', 'profile_filter_id', 'radarrA')
+radarrA_tag_filter = get_config_value('RADARR_A_TAG_FILTER', 'tag_filter', 'radarrA')
+radarrA_tag_filter_id = get_config_value('RADARR_A_TAG_FILTER_ID', 'tag_filter_id', 'radarrA')
 radarrA_language = get_config_value('RADARR_A_LANGUAGE', 'language', 'radarrA')
 radarrA_language_id = get_config_value('RADARR_A_LANGUAGE_ID', 'language_id', 'radarrA')
 radarrA_quality_match = get_config_value('RADARR_A_QUALITY_MATCH', 'quality_match', 'radarrA')
@@ -91,6 +93,9 @@ radarrB_profile = get_config_value('RADARR_B_PROFILE', 'profile', 'radarrB')
 radarrB_profile_id = get_config_value('RADARR_B_PROFILE_ID', 'profile_id', 'radarrB')
 radarrB_profile_filter = get_config_value('RADARR_B_PROFILE_FILTER', 'profile_filter', 'radarrB')
 radarrB_profile_filter_id = get_config_value('RADARR_B_PROFILE_FILTER_ID', 'profile_filter_id', 'radarrB')
+radarrB_tag_filter = get_config_value('RADARR_B_TAG_FILTER', 'tag_filter', 'radarrB')
+radarrB_tag_filter_id = get_config_value('RADARR_B_TAG_FILTER_ID', 'tag_filter_id', 'radarrB')
+
 radarrB_language = get_config_value('RADARR_B_LANGUAGE', 'language', 'radarrB')
 radarrB_language_id = get_config_value('RADARR_B_LANGUAGE_ID', 'language_id', 'radarrB')
 radarrB_quality_match = get_config_value('RADARR_B_QUALITY_MATCH', 'quality_match', 'radarrB')
@@ -273,6 +278,8 @@ if radarrA_url and radarrB_url:
     instanceA_profile_filter_id = radarrA_profile_filter_id
     instanceA_language = radarrA_language
     instanceA_language_id = radarrA_language_id
+    instanceA_tag_filter = radarrA_tag_filter and radarrA_tag_filter.split(',')
+    instanceA_tag_filter_id = radarrA_tag_filter_id and radarrA_tag_filter_id.split(',')
     instanceA_quality_match = radarrA_quality_match
     instanceA_blacklist = radarrA_blacklist
 
@@ -285,6 +292,8 @@ if radarrA_url and radarrB_url:
     instanceB_profile_filter_id = radarrB_profile_filter_id
     instanceB_language = radarrB_language
     instanceB_language_id = radarrB_language_id
+    instanceB_tag_filter = radarrB_tag_filter and radarrB_tag_filter.split(',')
+    instanceB_tag_filter_id = radarrB_tag_filter_id and radarrB_tag_filter_id.split(',')
     instanceB_quality_match = radarrB_quality_match
     instanceB_blacklist = radarrB_blacklist
 

--- a/index.py
+++ b/index.py
@@ -208,7 +208,7 @@ def sync_servers(instanceA_contents, instanceB_language_id, instanceB_contentIds
             instance_path = instanceB_path or dirname(content.get('path'))
 
             # if skipping missing files, we want to skip any that don't have files
-            if skip_missing:
+            if is_radarr and skip_missing:
                 content_has_file = content.get('hasFile')
                 if not content_has_file:
                     logging.debug(f'Skipping content {title} - file missing')

--- a/index.py
+++ b/index.py
@@ -25,7 +25,7 @@ from config import (
     get_status_path, get_content_path, get_profile_path, get_language_path, get_tag_path,
 
     is_in_docker, instance_sync_interval_seconds,
-    sync_bidirectionally, auto_search, monitor_new_content,
+    sync_bidirectionally, auto_search, skip_missing, monitor_new_content,
     tested_api_version, api_version, V3_API_PATH, is_test_run,
 )
 
@@ -206,6 +206,13 @@ def sync_servers(instanceA_contents, instanceB_language_id, instanceB_contentIds
         if content[content_id_key] not in instanceB_contentIds:
             title = content.get('title') or content.get('artistName')
             instance_path = instanceB_path or dirname(content.get('path'))
+
+            # if skipping missing files, we want to skip any that don't have files
+            if skip_missing:
+                content_has_file = content.get('hasFile')
+                if not content_has_file:
+                    logging.debug(f'Skipping content {title} - file missing')
+                    continue
 
             # if given this, we want to filter from instance by profile id
             if instanceA_profile_filter_id:


### PR DESCRIPTION
- `data=json.dumps()` output was not recognized as JSON by API - fixed by switching to `json=` param of session `POST`/`PUT` calls
- Markdown fixes as it was not formatting properly
- Adding proper param hint in conf for bidi functionality, i.e. `bidirectional` not `sync_bidirectionally`